### PR TITLE
Use instruction table to lookup and process bytes

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -8,7 +8,7 @@ pub enum CopyOf {
     VRAM,
 }
 
-pub trait Bus<'a>: Addressable + Timed {
+pub trait Bus<'a>: Addressable + Timed + std::fmt::Debug {
     fn create(
         ram: &'a mut dyn RAM<Addr = Self::Addr, Data = Self::Data>,
         gpu: &'a mut dyn GPU<'a, Addr = Self::Addr, Data = Self::Data>,

--- a/src/gameboy_bus.rs
+++ b/src/gameboy_bus.rs
@@ -4,6 +4,7 @@ use crate::gpu::GPU;
 use crate::ram::RAM;
 use crate::timed::*;
 
+#[derive(Debug)]
 pub struct Bus<'a> {
     ram: &'a mut dyn RAM<Addr = u16, Data = u8>,
     gpu: &'a mut dyn GPU<'a, Addr = u16, Data = u8>,

--- a/src/gameboy_cpu_inst.rs
+++ b/src/gameboy_cpu_inst.rs
@@ -1,5 +1,6 @@
 use crate::gameboy_cpu::*;
 
+#[derive(Clone, Copy, Debug)]
 pub enum Opcode {
     Invalid,
     NOP,
@@ -41,6 +42,7 @@ pub enum Opcode {
     EI,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum Operand {
     Value(Reg),
     DerefReg(Reg),
@@ -64,17 +66,18 @@ pub enum Operand {
     None,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct Instr {
-    opr: Opcode,
-    dst: Operand,
-    src: Operand,
-    cycles: usize,
+    pub opcode: Opcode,
+    pub dst: Operand,
+    pub src: Operand,
+    pub cycles: u32,
 }
 
 impl Instr {
-    const fn create(opr: Opcode, dst: Operand, src: Operand, cycles: usize) -> Self {
+    const fn create(opcode: Opcode, dst: Operand, src: Operand, cycles: u32) -> Self {
         Instr {
-            opr,
+            opcode,
             dst,
             src,
             cycles,

--- a/src/gameboy_gpu.rs
+++ b/src/gameboy_gpu.rs
@@ -3,6 +3,7 @@ use crate::gpu;
 use crate::ram::RAM;
 use crate::timed::{CycleTime, Timed};
 
+#[derive(Debug)]
 pub struct GPU<'a> {
     vram: &'a dyn RAM<Addr = u16, Data = u8>,
 }

--- a/src/gameboy_ram.rs
+++ b/src/gameboy_ram.rs
@@ -2,6 +2,7 @@ use crate::addressable::{AddressError, Addressable};
 use crate::ram;
 
 // Gameboy RAM; 16-bit address space, 8-bit memory width
+#[derive(Debug)]
 pub struct RAM<const SIZE: usize> {
     /// Inclusive start and end addresses
     start_addr: u16,

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -2,7 +2,7 @@ use crate::addressable::Addressable;
 use crate::ram::RAM;
 use crate::timed::Timed;
 
-pub trait GPU<'a>: Addressable + Timed {
+pub trait GPU<'a>: Addressable + Timed + std::fmt::Debug {
     fn create(vram: &'a dyn RAM<Addr = Self::Addr, Data = Self::Data>) -> Self
     where
         Self: Sized;

--- a/src/ram.rs
+++ b/src/ram.rs
@@ -1,6 +1,6 @@
 use crate::addressable::Addressable;
 
-pub trait RAM: Addressable {
+pub trait RAM: Addressable + std::fmt::Debug {
     fn create(start: Self::Addr) -> Self
     where
         Self: Sized;


### PR DESCRIPTION
* Return CPUError from CPU (now the top-level error, this should consume
  other errors and propagate them to someone executing the CPU)

Signed-off-by: Emil Hammarström <emil.a.hammarstrom@gmail.com>