### PR TITLE
Take ownership of trait vtables

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -8,10 +8,10 @@ pub enum CopyOf {
     VRAM,
 }
 
-pub trait Bus<'a>: Addressable + Timed + std::fmt::Debug {
+pub trait Bus: Addressable + Timed + std::fmt::Debug {
     fn create(
-        ram: &'a mut dyn RAM<Addr = Self::Addr, Data = Self::Data>,
-        gpu: &'a mut dyn GPU<'a, Addr = Self::Addr, Data = Self::Data>,
+        ram: Box<dyn RAM<Addr = Self::Addr, Data = Self::Data>>,
+        gpu: Box<dyn GPU<Addr = Self::Addr, Data = Self::Data>>,
     ) -> Self
     where
         Self: Sized;

--- a/src/gameboy_bus.rs
+++ b/src/gameboy_bus.rs
@@ -5,12 +5,12 @@ use crate::ram::RAM;
 use crate::timed::*;
 
 #[derive(Debug)]
-pub struct Bus<'a> {
-    ram: &'a mut dyn RAM<Addr = u16, Data = u8>,
-    gpu: &'a mut dyn GPU<'a, Addr = u16, Data = u8>,
+pub struct Bus {
+    ram: Box<dyn RAM<Addr = u16, Data = u8>>,
+    gpu: Box<dyn GPU<Addr = u16, Data = u8>>,
 }
 
-impl<'a> Addressable for Bus<'a> {
+impl Addressable for Bus {
     type Addr = u16;
     type Data = u8;
 
@@ -29,17 +29,17 @@ impl<'a> Addressable for Bus<'a> {
     }
 }
 
-impl<'a> Timed for Bus<'a> {
+impl Timed for Bus {
     fn catchup(&mut self, time: CycleTime) {
         self.gpu.catchup(time);
         // TODO: self.timer.catchup(time);
     }
 }
 
-impl<'a> bus::Bus<'a> for Bus<'a> {
+impl bus::Bus for Bus {
     fn create(
-        ram: &'a mut dyn RAM<Addr = Self::Addr, Data = Self::Data>,
-        gpu: &'a mut dyn GPU<'a, Addr = Self::Addr, Data = Self::Data>,
+        ram: Box<dyn RAM<Addr = Self::Addr, Data = Self::Data>>,
+        gpu: Box<dyn GPU<Addr = Self::Addr, Data = Self::Data>>,
     ) -> Self {
         Bus { ram, gpu }
     }

--- a/src/gameboy_gpu.rs
+++ b/src/gameboy_gpu.rs
@@ -4,12 +4,12 @@ use crate::ram::RAM;
 use crate::timed::{CycleTime, Timed};
 
 #[derive(Debug)]
-pub struct GPU<'a> {
-    vram: &'a dyn RAM<Addr = u16, Data = u8>,
+pub struct GPU {
+    vram: Box<dyn RAM<Addr = u16, Data = u8>>,
 }
 
-impl<'a> gpu::GPU<'a> for GPU<'a> {
-    fn create(vram: &'a dyn RAM<Addr = Self::Addr, Data = Self::Data>) -> Self {
+impl gpu::GPU for GPU {
+    fn create(vram: Box<dyn RAM<Addr = Self::Addr, Data = Self::Data>>) -> Self {
         GPU { vram }
     }
 
@@ -18,7 +18,7 @@ impl<'a> gpu::GPU<'a> for GPU<'a> {
     }
 }
 
-impl<'a> Addressable for GPU<'a> {
+impl Addressable for GPU {
     type Addr = u16;
     type Data = u8;
 
@@ -35,6 +35,6 @@ impl<'a> Addressable for GPU<'a> {
     }
 }
 
-impl<'a> Timed for GPU<'a> {
+impl Timed for GPU {
     fn catchup(&mut self, time: CycleTime) {}
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -2,8 +2,8 @@ use crate::addressable::Addressable;
 use crate::ram::RAM;
 use crate::timed::Timed;
 
-pub trait GPU<'a>: Addressable + Timed + std::fmt::Debug {
-    fn create(vram: &'a dyn RAM<Addr = Self::Addr, Data = Self::Data>) -> Self
+pub trait GPU: Addressable + Timed + std::fmt::Debug {
+    fn create(vram: Box<dyn RAM<Addr = Self::Addr, Data = Self::Data>>) -> Self
     where
         Self: Sized;
 


### PR DESCRIPTION
Heap allocate all trait objects and take ownership of them.
Since our traits are not sized we cannot take direct ownership of them.

Signed-off-by: Emil Hammarström <emil.a.hammarstrom@gmail.com>